### PR TITLE
fix connection context issue

### DIFF
--- a/kubetail
+++ b/kubetail
@@ -139,7 +139,7 @@ fi
 
 for pod in ${matching_pods[@]}; do
 	if [ ${#containers[@]} -eq 0 ]; then
-		pod_containers=($(kubectl get pod ${pod} --output=jsonpath='{.spec.containers[*].name}' | xargs -n1))
+		pod_containers=($(kubectl get pod ${pod} --context=${context} --output=jsonpath='{.spec.containers[*].name}' | xargs -n1))
 	else
 		pod_containers=("${containers[@]}")
 	fi


### PR DESCRIPTION
Script throws:
```The connection to the server localhost:8080 was refused - did you specify the right host or port?```
if containers haven't been supplied.

That happens because pod_containers' call doesn't pass context.