### PR TITLE
Fix support for k8s namespaces

### DIFF
--- a/kubetail
+++ b/kubetail
@@ -133,13 +133,13 @@ pod_logs_commands=()
 i=0
 
 # Allows for more colors, this is useful if one tails a lot pods
-if [ ${colored_output} != "false" ]; then	
+if [ ${colored_output} != "false" ]; then
 	export TERM=xterm-256color
 fi
 
 for pod in ${matching_pods[@]}; do
 	if [ ${#containers[@]} -eq 0 ]; then
-		pod_containers=($(kubectl get pod ${pod} --context=${context} --output=jsonpath='{.spec.containers[*].name}' | xargs -n1))
+		pod_containers=($(kubectl get pod ${pod} --context=${context} --output=jsonpath='{.spec.containers[*].name}' --namespace=${namespace} | xargs -n1))
 	else
 		pod_containers=("${containers[@]}")
 	fi


### PR DESCRIPTION
Example of error:
```
$ kubetail podname --namespace staging
Error from server (NotFound): pods "podname-2699064641-h54r8" not found
Error from server (NotFound): pods "podname-abcd-3329714192-hkgv4" not found
Error from server (NotFound): pods "podname-2050435824-zqrv7" not found
Error from server (NotFound): pods "podname-app-analytics-2289884096-g7vhr" not found
Error from server (NotFound): pods "podname-app-master-357819959-mvnff" not found
Error from server (NotFound): pods "podname-app-slave-2989938438-70z61" not found
Error from server (NotFound): pods "podname-app-worker-5296741-sjtrk" not found
Error from server (NotFound): pods "podname-redis-2806136820-77njn" not found
Error from server (NotFound): pods "podname-app-media-1355482752-rw3bp" not found
Error from server (NotFound): pods "podname-app-redis-512245278-51qdw" not found
Error from server (NotFound): pods "podname-app-shortener-3332421284-c3tnd" not found
Error from server (NotFound): pods "podname-app-shortener-app-397655291-d7m8n" not found
Error from server (NotFound): pods "podname-app-shortener-redis-517881005-ntmn3" not found
Will tail 0 logs...
```

Adding in the namespace flag seems to fix this, as the above command then works successfully. 