### PR TITLE
Display correct count of tailed logs

### DIFF
--- a/kubetail
+++ b/kubetail
@@ -270,7 +270,7 @@ for pod in ${matching_pods[@]}; do
 done
 
 # Preview pod colors
-echo "Will tail ${i} logs..."
+echo "Will tail ${#display_names_preview[@]} logs..."
 for preview in "${display_names_preview[@]}"; do
 	echo "$preview"
 done


### PR DESCRIPTION
i is mod 13 in the loop so any container count 13 and above breaks the counter.
We were seeing
`Will tail 8 logs...`
Should have been
`Will tail 21 logs...`