### PR TITLE
Add an option to list matching pods, then exit

### DIFF
--- a/kubetail
+++ b/kubetail
@@ -28,8 +28,9 @@ selector=()
 regex='substring'
 since="${default_since}"
 version="1.4.4-SNAPSHOT"
+matches_only=false
 
-usage="${PROGNAME} <search term> [-h] [-c] [-n] [-t] [-l] [-s] [-b] [-k] [-v] -- tail multiple Kubernetes pod logs at the same time
+usage="${PROGNAME} <search term> [-h] [-c] [-n] [-t] [-l] [-m] [-s] [-b] [-k] [-v] -- tail multiple Kubernetes pod logs at the same time
 
 where:
     -h, --help           Show this help text
@@ -38,6 +39,7 @@ where:
     -t, --context        The k8s context. ex. int1-context. Relies on ~/.kube/config for the contexts.
     -l, --selector       Label selector. If used the pod name is ignored.
     -n, --namespace      The Kubernetes namespace where the pods are located (defaults to \"default\")
+    -m, --matches        Print the names of the matched pods and containers, then exit.
     -s, --since          Only return logs newer than a relative duration like 5s, 2m, or 3h. Defaults to 10s.
     -b, --line-buffered  This flags indicates to use line-buffered. Defaults to false.
     -e, --regex          The type of name matching to use (regex|substring)
@@ -92,6 +94,9 @@ if [ "$#" -ne 0 ]; then
 			selector=(--selector "$2")
 			pod=""
 			;;
+        -m|--matches)
+            matches_only=true
+            ;;
 		-s|--since)
 			if [ -z "$2" ]; then
 				since="${default_since}"
@@ -276,6 +281,11 @@ echo "Will tail ${#display_names_preview[@]} logs..."
 for preview in "${display_names_preview[@]}"; do
 	echo "$preview"
 done
+
+if [[ ${matches_only} == true ]];
+then
+  exit 0
+fi
 
 # Join all log commands into one string separated by " & "
 join command_to_tail " & " "${logs_commands[@]}"

--- a/kubetail
+++ b/kubetail
@@ -28,7 +28,7 @@ selector=()
 regex='substring'
 since="${default_since}"
 version="1.4.4-SNAPSHOT"
-matches_only=false
+dry-run=false
 
 usage="${PROGNAME} <search term> [-h] [-c] [-n] [-t] [-l] [-m] [-s] [-b] [-k] [-v] -- tail multiple Kubernetes pod logs at the same time
 
@@ -39,7 +39,7 @@ where:
     -t, --context        The k8s context. ex. int1-context. Relies on ~/.kube/config for the contexts.
     -l, --selector       Label selector. If used the pod name is ignored.
     -n, --namespace      The Kubernetes namespace where the pods are located (defaults to \"default\")
-    -m, --matches        Print the names of the matched pods and containers, then exit.
+    -d, --dry-run        Print the names of the matched pods and containers, then exit.
     -s, --since          Only return logs newer than a relative duration like 5s, 2m, or 3h. Defaults to 10s.
     -b, --line-buffered  This flags indicates to use line-buffered. Defaults to false.
     -e, --regex          The type of name matching to use (regex|substring)
@@ -94,9 +94,9 @@ if [ "$#" -ne 0 ]; then
 			selector=(--selector "$2")
 			pod=""
 			;;
-        -m|--matches)
-            matches_only=true
-            ;;
+		-d|--dry-run)
+			dry-run=true
+			;;
 		-s|--since)
 			if [ -z "$2" ]; then
 				since="${default_since}"
@@ -225,7 +225,7 @@ function kill_kubectl_processes {
 }
 
 # Invoke the "kill_kubectl_processes" function when the script is stopped (including ctrl+c)
-# Note that "INT" is not used because if, for example, kubectl cannot find a container 
+# Note that "INT" is not used because if, for example, kubectl cannot find a container
 # (for example when running "kubetail something -c non_matching") we still need to delete
 # the temporary file in these cases as well.
 trap kill_kubectl_processes EXIT
@@ -282,7 +282,7 @@ for preview in "${display_names_preview[@]}"; do
 	echo "$preview"
 done
 
-if [[ ${matches_only} == true ]];
+if [[ ${dry-run} == true ]];
 then
   exit 0
 fi


### PR DESCRIPTION
"-m" or "--matches"

Using this option will cleanly exit the script after displaying all
matched pods and containers, without tailing any logs.