### PR TITLE
Kill subprocesses by process group id

### DIFF
--- a/kubetail
+++ b/kubetail
@@ -235,19 +235,9 @@ if [ ${colored_output} != "false" ]; then
 fi
 
 # Function that kills all kubectl processes that are started by kubetail in the background
-# It does this by reading from the "pid_temp_file" that contains the PID of all kubectl processes
 function kill_kubectl_processes {
-	while read p; do
-		# In order to not kill the wrong processes (for example if a kubectl process died and another process replaced its PID)
-		# we check that the process name contains "kubetail". It's not bulletproof since another kubetail process
-		# might have picked up the old PID but this is deemed unlikley.
-		pid_cmd=$(ps -p "$p" -o command=)
-		if [[ $pid_cmd == *kubetail* ]]; then
-			# Try killing gently first and then progress to more firm alternatives if this fails
-  			kill "$p" || kill -2 "$p" || kill -9 "$p" 2>/dev/null
-		fi
-	done < "$pid_temp_file"
-	rm ${pid_temp_file} 2>/dev/null
+	pgid="$( ps -o pgid "$$" | grep [0-9] | tr -d ' ' )"
+	kill -- -$pgid
 }
 
 # Invoke the "kill_kubectl_processes" function when the script is stopped (including ctrl+c)
@@ -255,10 +245,6 @@ function kill_kubectl_processes {
 # (for example when running "kubetail something -c non_matching") we still need to delete
 # the temporary file in these cases as well.
 trap kill_kubectl_processes EXIT
-
-PID=`echo $$` # Get the PID of this process
-pid_temp_file="/tmp/kubetail.${PID}" # Use the PID to create a temp file
-touch ${pid_temp_file} # Initiate the temp file
 
 for pod in ${matching_pods[@]}; do
 	if [ ${#containers[@]} -eq 0 ]; then
@@ -290,11 +276,10 @@ for pod in ${matching_pods[@]}; do
 
 		kubectl_cmd="${KUBECTL_BIN} ${context:+--context=${context}} logs ${pod} ${container} -f --since=${since} --tail=${tail} --namespace=${namespace} ${cluster}"
 		colorify_lines_cmd="while read line; do echo \"$colored_line\" | tail -n +1; done"
-		capture_pid_to_file="& echo "'$!'" >> ${pid_temp_file}"
 		if [ "z" == "z$jq_selector" ]; then
-			logs_commands+=("${kubectl_cmd} ${timestamps} | ${colorify_lines_cmd} ${capture_pid_to_file}");
+			logs_commands+=("${kubectl_cmd} ${timestamps} | ${colorify_lines_cmd}");
 		else
-			logs_commands+=("${kubectl_cmd} | jq --unbuffered -r -R --stream '. | fromjson? | $jq_selector ' | ${colorify_lines_cmd} ${capture_pid_to_file}");
+			logs_commands+=("${kubectl_cmd} | jq --unbuffered -r -R --stream '. | fromjson? | $jq_selector ' | ${colorify_lines_cmd}");
 		fi
 
 		# There are only 11 usable colors


### PR DESCRIPTION
Kill by process group id - potential fix for https://github.com/johanhaleby/kubetail/issues/49. See https://stackoverflow.com/questions/392022/whats-the-best-way-to-send-a-signal-to-all-members-of-a-process-group. I think it should work everywhere nowadays but not positive. Let me know what you think.