### PR TITLE
Add completion scripts and corresponding documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ You can also install kubetail using [brew](https://brew.sh/):
 
 Use `brew install --HEAD kubetail` to install the latest (unreleased) version.
 
+### Completion
+
+Install the [completion script](completion/) (bash/zsh/fish) to dynamically display the pods name (e.g. for Ubuntu, copy the scripts to `/etc/bash_completion.d/` and restart your terminal)
+
 ## Usage
 
 First find the names of all your pods:

--- a/completion/kubetail.bash
+++ b/completion/kubetail.bash
@@ -1,0 +1,9 @@
+_kubetail()
+{
+  local curr_arg;
+  curr_arg=${COMP_WORDS[COMP_CWORD]}
+  COMPREPLY=( $(compgen -W "$(kubectl get pods --no-headers | awk '{print $1}')" -- $curr_arg ) );
+}
+
+complete -F _kubetail kubetail
+

--- a/completion/kubetail.fish
+++ b/completion/kubetail.fish
@@ -1,0 +1,2 @@
+# kubetail
+complete -f -c kubetail -a "(kubectl get pods --no-headers | awk '{print $1}')"

--- a/completion/kubetail.zsh
+++ b/completion/kubetail.zsh
@@ -1,0 +1,2 @@
+#compdef kubetail
+_arguments "1: :($(kubectl get pods --no-headers | awk '{print $1}'))"


### PR DESCRIPTION
A small PR to add completion script for `bash`, `zsh` and `fish`, in order to avoid having to get the pods name before using kubetail.