### PR TITLE
Namespace from config

### DIFF
--- a/kubetail
+++ b/kubetail
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set -x
-
 KUBECTL_BIN=${KUBECTL_BIN:-"kubectl"}
 
 readonly PROGNAME=$(basename $0)

--- a/kubetail
+++ b/kubetail
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -x
+
 KUBECTL_BIN=${KUBECTL_BIN:-"kubectl"}
 
 readonly PROGNAME=$(basename $0)
@@ -32,6 +34,7 @@ since="${default_since}"
 version="1.6.1-SNAPSHOT"
 dryrun=false
 cluster=""
+namespace_arg=""
 
 usage="${PROGNAME} <search term> [-h] [-c] [-n] [-t] [-l] [-d] [-s] [-b] [-k] [-v] [-r] -- tail multiple Kubernetes pod logs at the same time
 
@@ -113,9 +116,10 @@ if [ "$#" -ne 0 ]; then
 			;;
 		-n|--namespace)
 			if [ -z "$2" ]; then
-				namespace="${default_namespace}"
+				# namespace="${default_namespace}"
+        echo "using namespace from context"
 			else
-				namespace="$2"
+				namespace_arg="--namespace $2"
 			fi
 			;;
 		-b|--line-buffered)
@@ -210,7 +214,7 @@ if [ "${regex}" == 'regex' ]; then
 fi
 
 # Get all pods matching the input and put them in an array. If no input then all pods are matched.
-matching_pods=(`${KUBECTL_BIN} get pods ${context:+--context=${context}} "${selector[@]}" --namespace=${namespace} ${cluster} --output=jsonpath='{.items[*].metadata.name}' | xargs -n1 | grep $grep_matcher "${pod}"`)
+matching_pods=(`${KUBECTL_BIN} get pods ${context:+--context=${context}} "${selector[@]}" ${namespace_arg} ${cluster} --output=jsonpath='{.items[*].metadata.name}' | xargs -n1 | grep $grep_matcher "${pod}"`)
 matching_pods_size=${#matching_pods[@]}
 
 if [ ${matching_pods_size} -eq 0 ]; then
@@ -248,7 +252,7 @@ trap kill_kubectl_processes EXIT
 
 for pod in ${matching_pods[@]}; do
 	if [ ${#containers[@]} -eq 0 ]; then
-		pod_containers=($(${KUBECTL_BIN} get pod ${pod} ${context:+--context=${context}} --output=jsonpath='{.spec.containers[*].name}' --namespace=${namespace} ${cluster} | xargs -n1))
+		pod_containers=($(${KUBECTL_BIN} get pod ${pod} ${context:+--context=${context}} --output=jsonpath='{.spec.containers[*].name}' ${namespace_arg} ${cluster} | xargs -n1))
 	else
 		pod_containers=("${containers[@]}")
 	fi
@@ -274,7 +278,7 @@ for pod in ${matching_pods[@]}; do
 			colored_line="${color_start}[${display_name}] \$line ${color_end}"
 		fi
 
-		kubectl_cmd="${KUBECTL_BIN} ${context:+--context=${context}} logs ${pod} ${container} -f --since=${since} --tail=${tail} --namespace=${namespace} ${cluster}"
+		kubectl_cmd="${KUBECTL_BIN} ${context:+--context=${context}} logs ${pod} ${container} -f --since=${since} --tail=${tail} ${namespace_arg} ${cluster}"
 		colorify_lines_cmd="while read line; do echo \"$colored_line\" | tail -n +1; done"
 		if [ "z" == "z$jq_selector" ]; then
 			logs_commands+=("${kubectl_cmd} ${timestamps} | ${colorify_lines_cmd}");

--- a/kubetail
+++ b/kubetail
@@ -114,8 +114,8 @@ if [ "$#" -ne 0 ]; then
 			;;
 		-n|--namespace)
 			if [ -z "$2" ]; then
-				# namespace="${default_namespace}"
-        echo "using namespace from context"
+				# using namespace from context
+				:
 			else
 				namespace_arg="--namespace $2"
 			fi


### PR DESCRIPTION
Hi!
We use kubens to see and set namespace in .kube/config:

$ kubens kube-system
Context "kubernetes03-eu-w1" modified.
Active namespace is "kube-system".

$ kubens
default
kube-public
**kube-system**

$ grep -C2 "namespace: kube-system" .kube/config
- context:
    cluster: kubernetes03-eu-w1
    namespace: kube-system
    user: kubernetes03-eu-w1
  name: kubernetes03-eu-w1

kubetail by default overrides this by setting --namespace=default if -n is not set. This patch lets kubectl handle this as expected.

(kubernetes03-eu-w1:kube-system)]$ kubetail kube-dns
Will tail 7 logs...
kube-dns-778977457c-d9c2d kubedns
kube-dns-778977457c-d9c2d dnsmasq
kube-dns-778977457c-d9c2d sidecar
kube-dns-778977457c-hjcrs kubedns
kube-dns-778977457c-hjcrs dnsmasq
kube-dns-778977457c-hjcrs sidecar
kube-dns-autoscaler-7db47cb9b7-6rmqc
...