### PR TITLE
retry tail on crashed pods

### DIFF
--- a/kubetail
+++ b/kubetail
@@ -288,7 +288,7 @@ for pod in ${matching_pods[@]}; do
 			colored_line="${color_start}[${display_name}] \$line ${color_end}"
 		fi
 
-		kubectl_cmd="${KUBECTL_BIN} ${context:+--context=${context}} logs ${pod} ${container} -f=${follow} --since=${since} --tail=${tail} ${namespace_arg} ${cluster}"
+		kubectl_cmd="while true ; do ${KUBECTL_BIN} ${context:+--context=${context}} logs ${pod} ${container} -f=${follow} --since=${since} --tail=${tail} ${namespace_arg} ${cluster} ; sleep 1 ; done"
 		colorify_lines_cmd="while read line; do echo \"$colored_line\" | tail -n +1; done"
 		if [ "z" == "z$jq_selector" ]; then
 			logs_commands+=("${kubectl_cmd} ${timestamps} | ${colorify_lines_cmd}");


### PR DESCRIPTION
Hack / proof of concept fix for #67.

Wrap the follow of an individual pod in a "while true" loop to keep monitoring a pod after it crashes and restarts.

Probably breaks horribly if you try and use kubetail without follow.