### PR TITLE
Improve jq filtering by not dropping non-JSON lines

### DIFF
--- a/kubetail
+++ b/kubetail
@@ -293,7 +293,7 @@ for pod in ${matching_pods[@]}; do
 		if [ "z" == "z$jq_selector" ]; then
 			logs_commands+=("${kubectl_cmd} ${timestamps} | ${colorify_lines_cmd}");
 		else
-			logs_commands+=("${kubectl_cmd} | jq --unbuffered -r -R --stream '. | fromjson? | $jq_selector ' | ${colorify_lines_cmd}");
+			logs_commands+=("${kubectl_cmd} | jq --unbuffered -r -R --stream '. as \$line | try (fromjson | $jq_selector) catch \$line' | ${colorify_lines_cmd}");
 		fi
 
 		# There are only 11 usable colors


### PR DESCRIPTION
The `fromjson?` syntax will drop lines that are not JSON. The `try/catch` syntax will let the line that cannot be parsed as JSON through. I think this is better.

Example:
```
kubectl tail -n gitlab gitlab-runner-5bbc4fbcb-qfxf5 --since 100h --jq . | head -n 10
Will tail 1 logs...
gitlab-runner-5bbc4fbcb-nt4rx
[gitlab-runner-5bbc4fbcb-nt4rx] Runtime platform                                    arch=amd64 os=linux pid=8 revision=cf91d5e1 version=11.4.2 
[gitlab-runner-5bbc4fbcb-nt4rx] Starting multi-runner from /etc/gitlab-runner/config.toml ...  builds=0 
[gitlab-runner-5bbc4fbcb-nt4rx] Running in system-mode.                            
[gitlab-runner-5bbc4fbcb-nt4rx]  
[gitlab-runner-5bbc4fbcb-nt4rx] { 
[gitlab-runner-5bbc4fbcb-nt4rx] "builds": 0, 
[gitlab-runner-5bbc4fbcb-nt4rx] "level": "info", 
[gitlab-runner-5bbc4fbcb-nt4rx] "msg": "Configuration loaded", 
```