### PR TITLE
namespace_arg should have default value

### DIFF
--- a/kubetail
+++ b/kubetail
@@ -36,7 +36,7 @@ since="${default_since}"
 version="1.6.8-SNAPSHOT"
 dryrun=false
 cluster=""
-namespace_arg=""
+namespace_arg="-n ${default_namespace}"
 
 usage="${PROGNAME} <search term> [-h] [-c] [-n] [-t] [-l] [-d] [-p] [-s] [-b] [-k] [-v] [-r] -- tail multiple Kubernetes pod logs at the same time
 


### PR DESCRIPTION
The default namespace_arg is empty, and as a result, the KUBETAIL_NAMESPACE setting is not working. This PR fixes it.