### PR TITLE
add color index to display names preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Example:
 
 	$ kubetail app2 -k false
 
-When multiple pods are being tailed and colored output is not set to false then you will see the color numbers used for each pod during the preview stage before the tailing of the logs begins. If there are any numbers that are difficult to see then they can be added to the colors to skip either by setting those using the `-z` command (comma seperated) or by setting the `KUBETAIL_SKIP_COLORS` environment variable.
+When multiple pods are being tailed and colored output is not set to false then you will see the color numbers used for each pod during the preview stage before the tailing of the logs begin. If there are any numbers that are difficult to see then they can be added to the colors to skip either by setting those using the `-z` command or by setting the `KUBETAIL_SKIP_COLORS` environment variable (either choice could be comma seperated).
 	
 ## Filtering / Highlighting etc
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,8 @@ By using the `-k` argument you can specify how kubetail makes use of colors (onl
 Example:
 
 	$ kubetail app2 -k false
-	
+
+When multiple pods are being tailed and colored output is not set to false then you will see the color numbers used for each pod during the preview stage before the tailing of the logs begins. If there are any numbers that are difficult to see then they can be added to the colors to skip either by setting those using the `-z` command (comma seperated) or by setting the `KUBETAIL_SKIP_COLORS` environment variable.
 	
 ## Filtering / Highlighting etc
 

--- a/kubetail
+++ b/kubetail
@@ -293,7 +293,7 @@ for pod in ${matching_pods[@]}; do
 		if [ ${colored_output} == "false" ]; then
 			display_names_preview+=("${display_name}")
 		else
-			display_names_preview+=("${color_start}${display_name}${color_end}")
+			display_names_preview+=("${color_start}${display_name}${color_end} - color: $color_index")
 		fi
 
 		if [ ${colored_output} == "false" ]; then

--- a/kubetail
+++ b/kubetail
@@ -293,15 +293,15 @@ for pod in ${matching_pods[@]}; do
 		if [ ${colored_output} == "false" ]; then
 			display_names_preview+=("${display_name}")
 		else
-			display_names_preview+=("${color_start}${display_name}${color_end} - color: $color_index")
+			display_names_preview+=("$color_index:${color_start}${display_name}${color_end}")
 		fi
 
 		if [ ${colored_output} == "false" ]; then
 			colored_line="[${display_name}] \$REPLY"
 		elif [ ${colored_output} == "pod" ]; then
-			colored_line="${color_start}[${display_name}]${color_end} \$REPLY"
+			colored_line="${color_start}[${color_end}${color_index}:${color_start}${display_name}]${color_end} \$REPLY"
 		else
-			colored_line="${color_start}[${display_name}] \$REPLY ${color_end}"
+			colored_line="${color_start}[${color_end}${color_index}:${color_start}${display_name}] \$REPLY ${color_end}"
 		fi
 
 		kubectl_cmd="${KUBECTL_BIN} ${context:+--context=${context}} logs ${pod} ${container} -f=${follow} --previous=${previous} --since=${since} --tail=${tail} ${namespace_arg} ${cluster}"


### PR DESCRIPTION
This solves #98 and I think it at the very least maybe a valid workaround for #92 

I considered making the feature only print through a flag but if this really can help differently-abled right out of the box then perhaps it should just be displayed when the display-names-preview is triggered as that really wouldn't hurt anyone.