### PR TITLE
add support for specific .kube/config file

### DIFF
--- a/kubetail
+++ b/kubetail
@@ -52,6 +52,7 @@ where:
     -c, --container         The name of the container to tail in the pod (if multiple containers are defined in the pod).
                             Defaults to all containers in the pod. Can be used multiple times.
     -t, --context           The k8s context. ex. int1-context. Relies on ~/.kube/config for the contexts.
+        --kubeconfig        You can specify other kubeconfig files by setting the --kubeconfig flag. Default ~/.kube/config
     -l, --selector          Label selector. If used the pod name is ignored.
     -n, --namespace         The Kubernetes namespace where the pods are located (defaults to \"${default_namespace}\")
     -f, --follow            Specify if the logs should be streamed. (true|false) Defaults to ${default_follow}.
@@ -107,6 +108,9 @@ if [ "$#" -ne 0 ]; then
 			;;
 		-t|--context)
 			context="$2"
+			;;
+		--kubeconfig)
+			kubeconfig="$2"
 			;;
 		-r|--cluster)
 			cluster="--cluster $2"
@@ -239,7 +243,7 @@ if [ "${regex}" == 'regex' ]; then
 fi
 
 # Get all pods matching the input and put them in an array. If no input then all pods are matched.
-matching_pods=(`${KUBECTL_BIN} get pods ${context:+--context=${context}} "${selector[@]}" ${namespace_arg} ${cluster} --output=jsonpath='{.items[*].metadata.name}' | xargs -n1 | grep --color=never $grep_matcher "${pod}"`)
+matching_pods=(`${KUBECTL_BIN} ${kubeconfig:+--kubeconfig=${kubeconfig}} get pods ${context:+--context=${context}} "${selector[@]}" ${namespace_arg} ${cluster} --output=jsonpath='{.items[*].metadata.name}' | xargs -n1 | grep --color=never $grep_matcher "${pod}"`)
 matching_pods_size=${#matching_pods[@]}
 
 if [ ${matching_pods_size} -eq 0 ]; then
@@ -276,7 +280,7 @@ function kill_kubectl_processes {
 trap kill_kubectl_processes EXIT
 
 # Putting all needed values in a variable so that multiple requests to Kubernetes api can be avoided, thus making it faster
-all_pods_containers=$(echo -e `${KUBECTL_BIN} get pods ${namespace_arg} ${context:+--context=${context}} --output=jsonpath="{range .items[*]}{.metadata.name} {.spec['containers', 'initContainers'][*].name} \n{end}"`)
+all_pods_containers=$(echo -e `${KUBECTL_BIN} ${kubeconfig:+--kubeconfig=${kubeconfig}} get pods ${namespace_arg} ${context:+--context=${context}} --output=jsonpath="{range .items[*]}{.metadata.name} {.spec['containers', 'initContainers'][*].name} \n{end}"`)
 
 
 for pod in ${matching_pods[@]}; do
@@ -317,7 +321,7 @@ for pod in ${matching_pods[@]}; do
 			colored_line="${color_start}[${color_end}${color_index_prefix}${color_start}${display_name}] \$REPLY ${color_end}"
 		fi
 
-		kubectl_cmd="${KUBECTL_BIN} ${context:+--context=${context}} logs ${pod} ${container} -f=${follow} --previous=${previous} --since=${since} --tail=${tail} ${namespace_arg} ${cluster}"
+		kubectl_cmd="${KUBECTL_BIN} ${kubeconfig:+--kubeconfig=${kubeconfig}} ${context:+--context=${context}} logs ${pod} ${container} -f=${follow} --previous=${previous} --since=${since} --tail=${tail} ${namespace_arg} ${cluster}"
 		colorify_lines_cmd="while read -r; do echo \"$colored_line\" | tail -n +1; done"
 		if [ "z" == "z$jq_selector" ]; then
 			logs_commands+=("${kubectl_cmd} ${timestamps} | ${colorify_lines_cmd}");


### PR DESCRIPTION
Hello,

I have multiple cluster and for safety reason I use a different .kube/config file in order to avoid doing harm to my production cluster.

I would love to see some support for  `--kubeconfig=` instead to realy on the default `.kube/config`

Thanks for this !