### PR TITLE
Check if kubectl is already installed or not

### DIFF
--- a/kubetail
+++ b/kubetail
@@ -1,6 +1,13 @@
 #!/bin/bash
 
-KUBECTL_BIN=${KUBECTL_BIN:-"kubectl"}
+if hash kubectl 2>/dev/null; then
+    KUBECTL_BIN=${KUBECTL_BIN:-"kubectl"}
+elif hash kubectl.exe 2>/dev/null; then
+    KUBECTL_BIN=${KUBECTL_BIN:-"kubectl.exe"}
+else
+    echo >&2 "kubectl is not installed"
+    exit 1
+fi
 
 readonly PROGNAME=$(basename $0)
 


### PR DESCRIPTION
I guess it is obvious that everyone will have `kubectl` already installed before having `kubetail`. But then there could be two cases to argue on: 
1. In case of windows, if there's only `kubectl.exe` binary then `kubetail` is likely to fail as it will not find raw `kubectl`.
2. What if someone doesn't have `kubectl` already installed.!