### PR TITLE
Prevent tight loops when network disconnects or pods deleted

### DIFF
--- a/kubetail
+++ b/kubetail
@@ -327,9 +327,9 @@ for pod in ${matching_pods[@]}; do
 		kubectl_cmd="${KUBECTL_BIN} ${context:+--context=${context}} logs ${pod} ${container} -f=${follow} --previous=${previous} --since=${since} --tail=${tail} ${namespace_arg} ${cluster}"
 		colorify_lines_cmd="while read -r; do echo \"$colored_line\" | tail -n +1; done"
 		if [ "z" == "z$jq_selector" ]; then
-			logs_commands+=("${kubectl_cmd} ${timestamps} | ${colorify_lines_cmd}");
+			logs_commands+=("(${kubectl_cmd} ${timestamps} | ${colorify_lines_cmd}; sleep 0.1)");
 		else
-			logs_commands+=("${kubectl_cmd} | jq --unbuffered -r -R --stream '. as \$line | try (fromjson | $jq_selector) catch \$line' | ${colorify_lines_cmd}");
+			logs_commands+=("(${kubectl_cmd} | jq --unbuffered -r -R --stream '. as \$line | try (fromjson | $jq_selector) catch \$line' | ${colorify_lines_cmd}; sleep 0.1)");
 		fi
 
 		# There are only 11 usable colors


### PR DESCRIPTION
I know there has been several discussions about how to gracefully handle pods going away but I find the most annoying issue to be when the vpn disconnects and causes kubetail to go in to a tight loop draining the laptop battery......

So, here is an alternate solution which mitigates the tight loop while still exposing errors about pods being deleted etc. without being too fancy.

It wraps the existing generated commands in command group and adds a small sleep (100ms) to prevent tight loops before the command group is put in the background.

sleeping obvious isn't great, but it might just be the simplest way to mitigate a very bad behaviour.

Thoughts?