### PR TITLE
Fix kubectl binary detection

### DIFF
--- a/kubetail
+++ b/kubetail
@@ -1,12 +1,16 @@
 #!/bin/bash
 
-if hash kubectl 2>/dev/null; then
-    KUBECTL_BIN=${KUBECTL_BIN:-"kubectl"}
-elif hash kubectl.exe 2>/dev/null; then
-    KUBECTL_BIN=${KUBECTL_BIN:-"kubectl.exe"}
-elif hash microk8s 2>/dev/null; then
-    KUBECTL_BIN=${KUBECTL_BIN:-"microk8s kubectl"}
-elif ! hash ${KUBECTL_BIN}; then    
+if [ -n "$KUBECTL_BIN" ]; then
+    if hash kubectl 2>/dev/null; then
+        KUBECTL_BIN='kubectl'
+    elif hash kubectl.exe 2>/dev/null; then
+        KUBECTL_BIN='kubectl.exe'
+    elif hash microk8s 2>/dev/null; then
+        KUBECTL_BIN='microk8s kubectl'
+    fi
+fi
+
+if ! hash "${KUBECTL_BIN}"; then    
     echo >&2 "kubectl is not installed"
     exit 1
 fi


### PR DESCRIPTION
1. Do not perform any detection if `KUBECTL_BIN` is passed explicly. Use the exact command or fail if it can't be used. The previous version is buggy because it checks for `hash kubectl` (and other), and then uses `KUBECTL_BIN` anyway.
2. Use `hash "$KUBECTL_BIN"` (one argument) for situations like `KUBECTL_BIN="/path/to/microk8s kubectl"`. The previous version is buggy because `hash $KUBECTL_BIN` checks for existence of each argument. Without doublequotes, it would check for existence of `/path/to/microk8s` AND `kubectl`, and fail if any of these are missing. With doublequotes, it'll check `/path/to/microk8s` and ignore arguments we wish to pass to the binary.
