### PR TITLE
add jq -c flag

### DIFF
--- a/kubetail
+++ b/kubetail
@@ -29,6 +29,7 @@ default_line_buffered="${KUBETAIL_LINE_BUFFERED:-}"
 default_colored_output="${KUBETAIL_COLORED_OUTPUT:-line}"
 default_timestamps="${KUBETAIL_TIMESTAMPS:-}"
 default_jq_selector="${KUBETAIL_JQ_SELECTOR:-}"
+default_jq_flags="${KUBETAIL_JQ_FLAGS:-}"
 default_skip_colors="${KUBETAIL_SKIP_COLORS:-7,8}"
 default_tail="${KUBETAIL_TAIL:--1}"
 default_show_color_index="${KUBETAIL_SHOW_COLOR_INDEX:-false}"
@@ -39,6 +40,7 @@ line_buffered="${default_line_buffered}"
 colored_output="${default_colored_output}"
 timestamps="${default_timestamps}"
 jq_selector="${default_jq_selector}"
+jq_flags="${default_jq_flags}"
 skip_colors="${default_skip_colors}"
 tail="${default_tail}"
 show_color_index="${default_show_color_index}"
@@ -74,6 +76,7 @@ where:
     -e, --regex             The type of name matching to use (regex|substring)
     -j, --jq                If your output is json - use this jq-selector to parse it.
                             example: --jq \".logger + \\\" \\\" + .message\"
+		--jqc				single line output from jq. (uses 'jq -c').
     -k, --colored-output    Use colored output (pod|line|false).
                             pod = only color pod name, line = color entire line, false = don't use any colors.
                             Defaults to ${default_colored_output}.
@@ -166,6 +169,14 @@ if [ "$#" -ne 0 ]; then
 			fi
 			;;
 		-j|--jq)
+			if [ -z "$2" ]; then
+				jq_selector="${default_jq_selector}"
+			else
+				jq_selector="$2"
+			fi
+			;;
+		--jqc)
+			jq_flags="-c"
 			if [ -z "$2" ]; then
 				jq_selector="${default_jq_selector}"
 			else
@@ -334,7 +345,7 @@ for pod in ${matching_pods[@]}; do
 		if [ "z" == "z$jq_selector" ]; then
 			logs_commands+=("${kubectl_cmd} ${timestamps} | ${colorify_lines_cmd}");
 		else
-			logs_commands+=("${kubectl_cmd} | jq --unbuffered -r -R --stream '. as \$line | try (fromjson | $jq_selector) catch \$line' | ${colorify_lines_cmd}");
+			logs_commands+=("${kubectl_cmd} | jq ${jq_flags} --unbuffered -r -R --stream '. as \$line | try (fromjson | $jq_selector) catch \$line' | ${colorify_lines_cmd}");
 		fi
 
 		# There are only 11 usable colors


### PR DESCRIPTION
Adds a new flag `--jqc` as an alternative to the `--jq` flag. This enables single line output when using `jq`.