### PR TITLE
Fix pod bash completion using default namespace form env variable

### DIFF
--- a/completion/kubetail.bash
+++ b/completion/kubetail.bash
@@ -1,6 +1,6 @@
 _findnamespace(){
     local next="0"
-    local namespace="";
+    local namespace="$KUBETAIL_NAMESPACE";
     for wo in "${COMP_WORDS[@]}"
     do
         if [ "$next" = "0" ]; then


### PR DESCRIPTION
Bash completions of pods names does not respect the namespace if it is not directly setted as argument with `-n | --namespace`, but with environment variable `KUBETAIL_NAMESPACE`.
With this fix, the namespace defaults to `KUBETAIL_NAMESPACE` env var, but the argument continue to take precedence if setted.