### PR TITLE
ignore unnecessary stderr if kubectl command not found

### DIFF
--- a/kubetail
+++ b/kubetail
@@ -9,7 +9,7 @@ if [ -z "${KUBECTL_BIN}" ]; then
 	fi
 fi
 
-if ! hash "${KUBECTL_BIN}"; then
+if ! hash "${KUBECTL_BIN}" 2>/dev/null; then
 	echo >&2 "kubectl is not installed"
 	exit 1
 fi


### PR DESCRIPTION
if kubeclt is not installed before, it is showing the following unnecessary error log
`line 13: hash: : not found` . 
In this pull request, the message has been ignored. 
