### PR TITLE
Add option to supply sed string to modify the log output

### DIFF
--- a/kubetail
+++ b/kubetail
@@ -158,7 +158,7 @@ if [ "$#" -ne 0 ]; then
 			fi
 			;;
 		-m|--modify)
-			modifyLineBySed="| sed -E $2"
+			modifyLineBySed="| sed -E '$2'"
 			;;
 		-n|--namespace)
 			if [ -z "$2" ]; then

--- a/kubetail
+++ b/kubetail
@@ -62,6 +62,7 @@ version="1.6.19-SNAPSHOT"
 dryrun=false
 cluster=""
 namespace_arg="-n ${default_namespace}"
+modifyLineBySed=""
 
 usage="${PROGNAME} <search term> [-h] [-c] [-n] [-t] [-l] [-f] [-d] [-P] [-p] [-s] [-b] [-e] [-j] [-k] [-z] [-v] [-r] [-i] -- tail multiple Kubernetes pod logs at the same time
 
@@ -96,6 +97,7 @@ where:
                             but if \"show-color-index\" is true then color index is added as well: \"[1:app-5b7ff6cbcd-bjv8n]\".
                             This is useful if you have color blindness or if you want to know which colors to exclude (see \"--skip-colors\").
                             Defaults to ${default_show_color_index}.
+    -m	--modify			Supply a sed replacement string. Beware when anchoring to the begining of the row that the it will begin with color code ansi characters and other invisible characters. 
 
 examples:
     ${PROGNAME} my-pod-v1
@@ -154,6 +156,9 @@ if [ "$#" -ne 0 ]; then
 			else
 				since="$2"
 			fi
+			;;
+		-m|--modify)
+			modifyLineBySed="| sed -E $2"
 			;;
 		-n|--namespace)
 			if [ -z "$2" ]; then
@@ -376,7 +381,7 @@ for pod in ${matching_pods[@]}; do
 		fi
 
 		kubectl_cmd="${KUBECTL_BIN} ${context:+--context=${context}} logs ${pod} ${container} -f=${follow} --previous=${previous} --since=${since} --tail=${tail} ${namespace_arg} ${cluster}"
-		colorify_lines_cmd="while read -r; do echo \"$colored_line\" | tail -n +1; done"
+		colorify_lines_cmd="while read -r; do echo \"$colored_line\" ${modifyLineBySed} | tail -n +1; done"
 		if [ "z" == "z$jq_selector" ]; then
 			logs_commands+=("${kubectl_cmd} ${timestamps} | ${colorify_lines_cmd}");
 		else


### PR DESCRIPTION
Hey! I use this tool like this:

`kt core -P false | sed -E 's/^(.*)[0-9]{4}-[0-9]{2}-[0-9]{2} ([0-9]{2}:[0-9]{2}):[0-9]{2}.[0-9]{3}  INFO \[[0-9a-f,]*\] . --- .*\] \.?([a-z]\.)+/\1\2 /'`

but i lose the colors when i do that

this PR allows me to keep the colors. with

`kt core -P false -m 's/^.*[0-9]{4}-[0-9]{2}-[0-9]{2} ([0-9]{2}:[0-9]{2}):[0-9]{2}.[0-9]{3}  INFO \[[0-9a-f,]*\] . --- .*\] \.?([a-z]\.)+/\1 /'`